### PR TITLE
update travis and appveyor to work on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - nightly
+  - stable
 sudo: false
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
@@ -10,4 +10,4 @@ script:
   - cargo test
   - cargo doc --no-deps
 after_success:
-  - travis-cargo --only nightly doc-upload
+  - travis-cargo --only stable doc-upload

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
+
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-  - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly
+  - rustup-init.exe -y --default-host %TARGET%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -V
   - cargo -V


### PR DESCRIPTION
Stable only for the moment, may add beta and nightly later on.
The reason is simply faster checks before PR validation as we may have several small PR before crates.io publishing.