### PR TITLE
force exact dimensions on xlsx ranges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,11 +213,11 @@ pub trait ExcelReader: Sized {
 impl Range {
 
     /// creates a new range
-    pub fn new(position: (u32, u32), size: (usize, usize), data: Vec<DataType>) -> Range {
+    pub fn new(position: (u32, u32), size: (usize, usize)) -> Range {
         Range {
             position: position,
             size: size,
-            inner: data,
+            inner: vec![DataType::Empty; size.0 * size.1],
         }
     }
 
@@ -229,6 +229,13 @@ impl Range {
     /// get size
     pub fn get_size(&self) -> (usize, usize) {
         self.size
+    }
+
+    /// set inner value
+    pub fn set_value(&mut self, pos: (u32, u32), value: DataType) {
+        assert!(self.position <= pos);
+        let idx = (pos.0 - self.position.0) * self.size.1 as u32 + pos.1 - self.position.1;
+        self.inner[idx as usize] = value;
     }
 
     /// get cell value

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -54,6 +54,7 @@ fn issue_6() {
     assert_eq!(r.next(), Some(&[String("ab".to_string())] as &[DataType]));
     assert_eq!(r.next(), Some(&[Bool(false)] as &[DataType]));
     assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
     assert_eq!(r.next(), None);
 }
 
@@ -71,6 +72,19 @@ fn error_file() {
     assert_eq!(r.next(), Some(&[Error(Ref)] as &[DataType]));
     assert_eq!(r.next(), Some(&[Error(Num)] as &[DataType]));
     assert_eq!(r.next(), Some(&[Error(NA)] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
+    assert_eq!(r.next(), Some(&[Empty] as &[DataType]));
     assert_eq!(r.next(), None);
 }
 


### PR DESCRIPTION
closes #29 

I forced the size of the range to the dimension read in `/worksheet/dimension` and gets the `c[@r]` attribute to know the index within the range.

I consequently modified the tests accordingly (many empty rows as per the range dimension).

There may be an impact on performance (bigger output + parsing every cell reference) but I guess it is minimal.